### PR TITLE
Fix accounting of newlines when performing line-mode diffs

### DIFF
--- a/src/Diff.php
+++ b/src/Diff.php
@@ -44,6 +44,11 @@ class Diff
     const EQUAL  = 0;
 
     /**
+     * Number of characters at which line mode speedup is employed.
+     */
+    const LINEMODE_THRESOLD = 100;
+
+    /**
      * @var float Number of seconds to map a diff before giving up (0 for infinity).
      */
     protected $timeout = 1.0;
@@ -1099,7 +1104,9 @@ class Diff
             }
         }
 
-        if ($checklines && mb_strlen($text1) > 100 && mb_strlen($text2) > 100) {
+        if ($checklines
+          && mb_strlen($text1) > Diff::LINEMODE_THRESOLD
+          && mb_strlen($text2) > Diff::LINEMODE_THRESOLD) {
             return $this->lineMode($text1, $text2, $deadline);
         }
 

--- a/src/DiffToolkit.php
+++ b/src/DiffToolkit.php
@@ -293,18 +293,20 @@ class DiffToolkit {
         // explode('\n', $text) would temporarily double our memory footprint,
         // but mb_strpos() and mb_substr() work slow
         $lines = explode($delimiter, $text);
+        $last_line_has_delimiter = end($lines) === '';
+        if ($last_line_has_delimiter) {
+            array_pop($lines);
+        }
         foreach ($lines as $i => $line) {
-            if (mb_strlen($line)) {
-                if (isset($lines[$i + 1])) {
-                    $line .= $delimiter;
-                }
-                if (isset($lineHash[$line])) {
-                    $chars .= Utils::unicodeChr($lineHash[$line]);
-                } else {
-                    $lineArray[] = $line;
-                    $lineHash[$line] = count($lineArray) - 1;
-                    $chars .= Utils::unicodeChr(count($lineArray) - 1);
-                }
+            if ($i + 1 < count($lines) || $last_line_has_delimiter) {
+                $line .= $delimiter;
+            }
+            if (array_key_exists($line, $lineHash)) {
+                $chars .= Utils::unicodeChr($lineHash[$line]);
+            } else {
+                $lineArray[] = $line;
+                $lineHash[$line] = count($lineArray) - 1;
+                $chars .= Utils::unicodeChr(count($lineArray) - 1);
             }
         }
 

--- a/tests/DiffMatchPatchTest.php
+++ b/tests/DiffMatchPatchTest.php
@@ -165,13 +165,36 @@ class DiffMatchPatchTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->dmp->patch_toText($patches));
     }
 
-    public function testPatchApply()
-    {
-        $patches = $this->dmp->patch_make("The quick brown fox jumps over the lazy dog.", "That quick brown fox jumped over a lazy dog.");
-        $this->assertEquals(
-            array("That quick red rabbit jumped over a tired tiger.", array(true, true,)),
-            $this->dmp->patch_apply($patches, "The quick red rabbit jumps over the tired tiger.")
-        );
+    protected function _testPatchApply($text1, $text2, $target = NULL, $expected = NULL) {
+      if ($target === NULL) {
+        $target = $text1;
+      }
+      if ($expected === NULL) {
+        $expected = $text2;
+      }
+
+      $patches = $this->dmp->patch_make($text1, $text2);
+      $this->assertEquals(
+        array($expected, array_map(function() { return TRUE; }, $patches)),
+        $this->dmp->patch_apply($patches, $target)
+      );
+    }
+
+    public function testPatchApply() {
+      $this->_testPatchApply(
+        "The quick brown fox jumps over the lazy dog.",
+        "That quick brown fox jumped over a lazy dog.",
+        "The quick red rabbit jumps over the tired tiger.",
+        "That quick red rabbit jumped over a tired tiger."
+      );
+    }
+
+    public function testPatchApply_2() {
+      $linemode_pad = str_pad('pad', Diff::LINEMODE_THRESOLD, 'x');
+      $this->_testPatchApply(
+        "line number one\n\nLine number three" . $linemode_pad . 'a',
+        "LINE number one\nThe second line\n\nThis is Line number three" . $linemode_pad . 'b'
+      );
     }
 
 }

--- a/tests/DiffTest.php
+++ b/tests/DiffTest.php
@@ -843,8 +843,10 @@ class DiffTest extends \PHPUnit_Framework_TestCase
         // Test the linemode speedup.
         // Must be long to pass the 100 char cutoff.
         // Simple line-mode.
-        $a = str_repeat("1234567890\n", 13);
-        $b = str_repeat("abcdefghij\n", 13);
+        $a = "12345\n\n67890\n";
+        $a = str_repeat($a, ceil(Diff::LINEMODE_THRESOLD / strlen($a)));
+        $b = "abcde\n\nfghij\n";
+        $b = str_repeat($b, ceil(Diff::LINEMODE_THRESOLD / strlen($b)));
         $this->assertEquals(
             $this->d->main($a, $b, false)->getChanges(),
             $this->d->main($a, $b, true)->getChanges()


### PR DESCRIPTION
When creating a diff of a > 100 line source file, consecutive newlines were being dropped from the input (because the explode()ed line was an empty string, and all empty strings were skipped.)
