### PR TITLE
Fix string comparison

### DIFF
--- a/src/Diff.php
+++ b/src/Diff.php
@@ -270,7 +270,7 @@ class Diff
             }
         }
 
-        if ($diffs[count($diffs) - 1][1] == '') {
+        if ($diffs[count($diffs) - 1][1] === '') {
             array_pop($diffs);
         }
 
@@ -283,13 +283,13 @@ class Diff
         while ($pointer < count($diffs) - 1) {
             if ($diffs[$pointer - 1][0] == self::EQUAL && $diffs[$pointer + 1][0] == self::EQUAL) {
                 // This is a single edit surrounded by equalities.
-                if (mb_substr($diffs[$pointer][1], -mb_strlen($diffs[$pointer - 1][1])) == $diffs[$pointer - 1][1]) {
+                if (mb_substr($diffs[$pointer][1], -mb_strlen($diffs[$pointer - 1][1])) === $diffs[$pointer - 1][1]) {
                     // Shift the edit over the previous equality.
                     $diffs[$pointer][1] = $diffs[$pointer - 1][1] . mb_substr($diffs[$pointer][1], 0, -mb_strlen($diffs[$pointer - 1][1]));
                     $diffs[$pointer + 1][1] = $diffs[$pointer - 1][1] . $diffs[$pointer + 1][1];
                     array_splice($diffs, $pointer - 1, 1);
                     $changes = true;
-                } elseif (mb_substr($diffs[$pointer][1], 0, mb_strlen($diffs[$pointer + 1][1])) == $diffs[$pointer + 1][1]) {
+                } elseif (mb_substr($diffs[$pointer][1], 0, mb_strlen($diffs[$pointer + 1][1])) === $diffs[$pointer + 1][1]) {
                     // Shift the edit over the next equality.
                     $diffs[$pointer - 1][1] = $diffs[$pointer - 1][1] . $diffs[$pointer + 1][1];
                     $diffs[$pointer][1] = mb_substr($diffs[$pointer][1], mb_strlen($diffs[$pointer + 1][1])) . $diffs[$pointer + 1][1];
@@ -343,7 +343,7 @@ class Diff
                 $bestEdit = $edit;
                 $bestEquality2 = $equality2;
                 $bestScore = $this->cleanupSemanticScore($equality1, $edit) + $this->cleanupSemanticScore($edit, $equality2);
-                while ($edit && $equality2 && mb_substr($edit, 0, 1) == mb_substr($equality2, 0, 1)) {
+                while ($edit && $equality2 && mb_substr($edit, 0, 1) === mb_substr($equality2, 0, 1)) {
                     $equality1 .= mb_substr($edit, 0, 1);
                     $edit = mb_substr($edit, 1) . mb_substr($equality2, 0, 1);
                     $equality2 = mb_substr($equality2, 1);
@@ -356,16 +356,16 @@ class Diff
                         $bestEquality2 = $equality2;
                     }
                 }
-                if ($diffs[$pointer - 1][1] != $bestEquality1) {
+                if ($diffs[$pointer - 1][1] !== $bestEquality1) {
                     // We have an improvement, save it back to the diff.
-                    if ($bestEquality1 != '') {
+                    if ($bestEquality1 !== '') {
                         $diffs[$pointer - 1][1] = $bestEquality1;
                     } else {
                         array_splice($diffs, $pointer - 1, 1);
                         $pointer -= 1;
                     }
                     $diffs[$pointer][1] = $bestEdit;
-                    if ($bestEquality2 != '') {
+                    if ($bestEquality2 !== '') {
                         $diffs[$pointer + 1][1] = $bestEquality2;
                     } else {
                         array_splice($diffs, $pointer + 1, 1);
@@ -391,7 +391,7 @@ class Diff
      */
     protected function cleanupSemanticScore($one, $two)
     {
-        if ($one == '' || $two == '') {
+        if ($one === '' || $two === '') {
             // Edges are the best.
             return 6;
         }
@@ -472,7 +472,7 @@ class Diff
                 }
                 // Eliminate an equality that is smaller or equal to the edits on both sides of it.
                 if (
-                    $lastequality != '' &&
+                    $lastequality !== null &&
                     mb_strlen($lastequality) <= max($length_insertions1, $length_deletions1) &&
                     mb_strlen($lastequality) <= max($length_insertions2, $length_deletions2)
                 ) {
@@ -623,7 +623,7 @@ class Diff
                 // <ins>A</ins><del>B</del>X<del>C</del>
                 // TODO refactor condition
                 if (
-                    $lastequality != '' &&
+                    $lastequality !== null &&
                     (
                         ($pre_ins && $pre_del && $post_ins && $post_del) ||
                         (
@@ -797,7 +797,7 @@ class Diff
         $pointer = 0;
         $tokens = explode("\t", $delta);
         foreach ($tokens as $token) {
-            if ($token == '') {
+            if ($token === '') {
                 // Blank tokens are ok (from a trailing \t).
                 continue;
             }
@@ -824,7 +824,7 @@ class Diff
                     $text = mb_substr($text1, $pointer, $n);
                     $pointer += $n;
                     $diffs[] = array(
-                        $op == '=' ? self::EQUAL : self::DELETE,
+                        $op === '=' ? self::EQUAL : self::DELETE,
                         $text,
                     );
                     break;
@@ -954,8 +954,8 @@ class Diff
         }
 
         // Check for equality (speedup).
-        if ($text1 == $text2) {
-            if ($text1 != '') {
+        if ($text1 === $text2) {
+            if ($text1 !== '') {
                 $this->setChanges(array(
                     array(self::EQUAL, $text1),
                 ));
@@ -966,7 +966,7 @@ class Diff
 
         $prevInternalEncoding = mb_internal_encoding();
         $newInternalEncoding = 'UCS-2LE';
-        if ($prevInternalEncoding != $newInternalEncoding) {
+        if ($prevInternalEncoding !== $newInternalEncoding) {
             mb_internal_encoding($newInternalEncoding);
 
             $errorReportingLevel = error_reporting();
@@ -1012,14 +1012,14 @@ class Diff
         $diffs = $this->compute($text1, $text2, $checklines, $deadline);
 
         // Restore the prefix and suffix.
-        if ($commonPrefix != '') {
+        if ($commonPrefix !== '') {
             array_unshift($diffs, array(self::EQUAL, $commonPrefix));
         }
-        if ($commonSuffix != '') {
+        if ($commonSuffix !== '') {
             array_push($diffs, array(self::EQUAL, $commonSuffix));
         }
 
-        if ($newInternalEncoding != $prevInternalEncoding) {
+        if ($newInternalEncoding !== $prevInternalEncoding) {
             mb_internal_encoding($prevInternalEncoding);
             foreach ($diffs as &$change) {
                 $change[1] = iconv($newInternalEncoding, $prevInternalEncoding, $change[1]);
@@ -1049,14 +1049,14 @@ class Diff
      */
     protected function compute($text1, $text2, $checklines, $deadline)
     {
-        if ($text1 == '') {
+        if ($text1 === '') {
             // Just add some text (speedup).
             return array(
                 array(self::INSERT, $text2),
             );
         }
 
-        if ($text2 == '') {
+        if ($text2 === '') {
             // Just delete some text (speedup).
             return array(
                 array(self::DELETE, $text1),
@@ -1249,7 +1249,7 @@ class Diff
                     $x1 = $v1[$k1Offset - 1] + 1;
                 }
                 $y1 = $x1 - $k1;
-                while ($x1 < $text1Length && $y1 < $text2Length && mb_substr($text1, $x1, 1) == mb_substr($text2, $y1, 1)) {
+                while ($x1 < $text1Length && $y1 < $text2Length && mb_substr($text1, $x1, 1) === mb_substr($text2, $y1, 1)) {
                     $x1++;
                     $y1++;
                 }
@@ -1282,7 +1282,7 @@ class Diff
                     $x2 = $v2[$k2Offset - 1] + 1;
                 }
                 $y2 = $x2 - $k2;
-                while ($x2 < $text1Length && $y2 < $text2Length && mb_substr($text1, -$x2 - 1, 1) == mb_substr($text2, -$y2 - 1, 1)) {
+                while ($x2 < $text1Length && $y2 < $text2Length && mb_substr($text1, -$x2 - 1, 1) === mb_substr($text2, -$y2 - 1, 1)) {
                     $x2++;
                     $y2++;
                 }

--- a/src/DiffToolkit.php
+++ b/src/DiffToolkit.php
@@ -40,7 +40,7 @@ class DiffToolkit {
     public function commonPrefix($text1, $text2)
     {
         // Quick check for common null cases.
-        if ($text1 == '' || $text2 == '' || mb_substr($text1, 0, 1) != mb_substr($text2, 0, 1)) {
+        if ($text1 === '' || $text2 === '' || mb_substr($text1, 0, 1) !== mb_substr($text2, 0, 1)) {
             return 0;
         }
         // Binary search.
@@ -50,7 +50,7 @@ class DiffToolkit {
         $pointermid = $pointermax;
         $pointerstart = 0;
         while ($pointermin < $pointermid) {
-            if (mb_substr($text1, $pointerstart, $pointermid - $pointerstart) == mb_substr($text2, $pointerstart,
+            if (mb_substr($text1, $pointerstart, $pointermid - $pointerstart) === mb_substr($text2, $pointerstart,
                     $pointermid - $pointerstart)
             ) {
                 $pointermin = $pointermid;
@@ -75,7 +75,7 @@ class DiffToolkit {
     public function commonSuffix($text1, $text2)
     {
         // Quick check for common null cases.
-        if ($text1 == '' || $text2 == '' || mb_substr($text1, -1, 1) != mb_substr($text2, -1, 1)) {
+        if ($text1 === '' || $text2 === '' || mb_substr($text1, -1, 1) !== mb_substr($text2, -1, 1)) {
             return 0;
         }
         // Binary search.
@@ -85,7 +85,7 @@ class DiffToolkit {
         $pointermid = $pointermax;
         $pointerend = 0;
         while ($pointermin < $pointermid) {
-            if (mb_substr($text1, -$pointermid, $pointermid - $pointerend) == mb_substr($text2, -$pointermid,
+            if (mb_substr($text1, -$pointermid, $pointermid - $pointerend) === mb_substr($text2, -$pointermid,
                     $pointermid - $pointerend)
             ) {
                 $pointermin = $pointermid;
@@ -127,7 +127,7 @@ class DiffToolkit {
         $text_length = min($text1_length, $text2_length);
 
         // Quick check for the worst case.
-        if ($text1 == $text2) {
+        if ($text1 === $text2) {
             return $text_length;
         }
 
@@ -143,7 +143,7 @@ class DiffToolkit {
                 break;
             }
             $length += $found;
-            if ($found == 0 || mb_substr($text1, -$length) == mb_substr($text2, 0, $length)) {
+            if ($found == 0 || mb_substr($text1, -$length) === mb_substr($text2, 0, $length)) {
                 $best = $length;
                 $length += 1;
             }
@@ -256,7 +256,7 @@ class DiffToolkit {
      */
     public function linesToChars($text1, $text2)
     {
-        // e.g. $lineArray[4] == "Hello\n"
+        // e.g. $lineArray[4] === "Hello\n"
         $lineArray = array();
         // e.g. $lineHash["Hello\n"] == 4
         $lineHash = array();

--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -125,10 +125,10 @@ class Matcher {
         }
 
         $loc = max(0, min($loc, mb_strlen($text)));
-        if ($text == $pattern) {
+        if ($text === $pattern) {
             // Shortcut (potentially not guaranteed by the algorithm)
             return 0;
-        } elseif ($text == '') {
+        } elseif ($text === '') {
             // Nothing to match.
             return -1;
         } elseif (mb_substr($text, $loc, mb_strlen($pattern)) == $pattern) {

--- a/src/Patch.php
+++ b/src/Patch.php
@@ -140,20 +140,20 @@ class Patch
             }
             $patch = new PatchObject();
             $patch->setStart1($m[1]);
-            if ($m[2] == '') {
+            if ($m[2] === '') {
                 $patch->setStart1($patch->getStart1() - 1);
                 $patch->setLength1(1);
-            } elseif ($m[2] == '0') {
+            } elseif ($m[2] === '0') {
                 $patch->setLength1(0);
             } else {
                 $patch->setStart1($patch->getStart1() - 1);
                 $patch->setLength1($m[2]);
             }
             $patch->setStart2($m[3]);
-            if ($m[4] == '') {
+            if ($m[4] === '') {
                 $patch->setStart2($patch->getStart2() - 1);
                 $patch->setLength2(1);
-            } elseif ($m[4] == '0') {
+            } elseif ($m[4] === '0') {
                 $patch->setLength2(0);
             } else {
                 $patch->setStart2($patch->getStart2() - 1);
@@ -235,7 +235,7 @@ class Patch
         // If two different matches are found, increase the pattern length.
         $matcher = $this->getMatcher();
         while (
-            (!$pattern || mb_strpos($text, $pattern) !== mb_strrpos($text, $pattern)) &&
+            ($pattern === '' || mb_strpos($text, $pattern) !== mb_strrpos($text, $pattern)) &&
             ($matcher->getMaxBits() == 0 || mb_strlen($pattern) < $matcher->getMaxBits() - 2 * $this->getMargin())
         ) {
             $padding += $this->getMargin();
@@ -250,12 +250,12 @@ class Patch
 
         // Add the prefix.
         $prefix = mb_substr($text, max(0, $patch->getStart2() - $padding), min($patch->getStart2(), $padding));
-        if ($prefix != '') {
+        if ($prefix !== '') {
             $patch->prependChanges(array(Diff::EQUAL, $prefix));
         }
         // Add the suffix.
         $suffix = mb_substr($text, $patch->getStart2() + $patch->getLength1(), $padding);
-        if ($suffix != '') {
+        if ($suffix !== '') {
             $patch->appendChanges(array(Diff::EQUAL, $suffix));
         }
 
@@ -437,7 +437,7 @@ class Patch
                 $patch->setStart1($start1 - $preContextLen);
                 $patch->setStart2($start2 - $preContextLen);
 
-                if ($preContext != '') {
+                if ($preContext !== '') {
                     $patch->setLength1($preContextLen);
                     $patch->setLength2($preContextLen);
                     $patch->appendChanges(array(Diff::EQUAL, $preContext));
@@ -478,7 +478,7 @@ class Patch
                             $empty = false;
                         }
 
-                        if ($diffText == $bigPatchDiffs[0][1]) {
+                        if ($diffText === $bigPatchDiffs[0][1]) {
                             array_shift($bigPatchDiffs);
                         } else {
                             $bigPatchDiffs[0][1] = mb_substr($bigPatchDiffs[0][1], $diffTextLen);
@@ -497,7 +497,7 @@ class Patch
                 $diff->setChanges($bigPatchDiffs);
                 $postContext = $diff->text1();
                 $postContext = mb_substr($postContext, 0, $this->getMargin());
-                if ($postContext != '') {
+                if ($postContext !== '') {
                     $patch->setLength1($patch->getLength1() + mb_strlen($postContext));
                     $patch->setLength2($patch->getLength2() + mb_strlen($postContext));
                     if (
@@ -660,7 +660,7 @@ class Patch
                 } else {
                     $text2 = mb_substr($text, $startLoc, $endLoc + $maxBits - $startLoc);
                 }
-                if ($text1 == $text2) {
+                if ($text1 === $text2) {
                     // Perfect match, just shove the replacement text in.
                     $text = mb_substr($text, 0, $startLoc) . $diff->text2() .
                         mb_substr($text, $startLoc + $text1Len);

--- a/tests/ChrBenchmark.php
+++ b/tests/ChrBenchmark.php
@@ -70,7 +70,7 @@ function unicodeChr4($code)
 
 function unicodeOrd1($char)
 {
-    if (mb_internal_encoding() != 'UCS-4LE') {
+    if (mb_internal_encoding() !== 'UCS-4LE') {
         $char = iconv(mb_internal_encoding(), 'UCS-4LE', $char);
     }
     $code = 0;

--- a/tests/DiffTest.php
+++ b/tests/DiffTest.php
@@ -921,4 +921,30 @@ class DiffTest extends TestCase
         }
     }
 
+    public function testNumeric()
+    {
+        $this->assertEquals(
+            array(
+                array(Diff::DELETE, "0"),
+                array(Diff::INSERT, "1"),
+            ),
+            $this->d->main("0", "1", false)->getChanges()
+        );
+
+        $this->assertEquals(
+            array(
+                array(Diff::EQUAL, "0"),
+                array(Diff::INSERT, "0"),
+            ),
+            $this->d->main("0", "00", false)->getChanges()
+        );
+
+        $this->assertEquals(
+            array(
+                array(Diff::INSERT, "0"),
+                array(Diff::EQUAL, "1"),
+            ),
+            $this->d->main("1", "01", false)->getChanges()
+        );
+	}
 }


### PR DESCRIPTION
Fix string comparison to use operator `===` as PHP tries numeric comparison whenever possible for operator `==`:

```
assert('0' == '00');
assert(null == '');

use DiffMatchPatch\Diff;
$dmp = new Diff();
var_dump($dmp->main('1', '00000000000000001', false)->getChanges());
// array(1) {
//   [0]=>
//   array(2) {
//     [0]=>
//     int(0)
//     [1]=>
//     string(1) "1"
//   }
// }

```