### PR TITLE
Fix internal encoding left on UCS-2LE after switching to UCS-4LE.

### DIFF
--- a/src/Diff.php
+++ b/src/Diff.php
@@ -967,8 +967,6 @@ class Diff
         $prevInternalEncoding = mb_internal_encoding();
         $newInternalEncoding = 'UCS-2LE';
         if ($prevInternalEncoding != $newInternalEncoding) {
-            mb_internal_encoding($newInternalEncoding);
-
             $errorReportingLevel = error_reporting();
             error_reporting($errorReportingLevel & ~E_NOTICE);
 
@@ -981,6 +979,8 @@ class Diff
                 $text1Draft = iconv($prevInternalEncoding, $newInternalEncoding, $text1);
                 $text2Draft = iconv($prevInternalEncoding, $newInternalEncoding, $text2);
             }
+
+            mb_internal_encoding($newInternalEncoding);
 
             $text1 = $text1Draft;
             $text2 = $text2Draft;

--- a/src/DiffMatchPatch.php
+++ b/src/DiffMatchPatch.php
@@ -66,7 +66,7 @@ class DiffMatchPatch
      */
     protected $diff;
     /**
-     * @var Match
+     * @var Matcher
      */
     protected $match;
     /**
@@ -154,7 +154,7 @@ class DiffMatchPatch
     public function __construct()
     {
         $this->diff = new Diff();
-        $this->match = new Match();
+        $this->match = new Matcher();
         $this->patch = new Patch($this->diff, $this->match);
     }
 

--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -28,7 +28,7 @@ namespace DiffMatchPatch;
  * @author Neil Fraser <fraser@google.com>
  * @author Daniil Skrobov <yetanotherape@gmail.com>
  */
-class Match {
+class Matcher {
 
     /**
      * @var float At what point is no match declared (0.0 = perfection, 1.0 = very loose).

--- a/src/Patch.php
+++ b/src/Patch.php
@@ -46,18 +46,18 @@ class Patch
      */
     protected $diff;
     /**
-     * @var Match
+     * @var Matcher
      */
     protected $match;
 
     /**
      * @param Diff|null $diff
-     * @param Match|null $match
+     * @param Matcher|null $match
      */
-    public function __construct(Diff $diff = null, Match $match = null)
+    public function __construct(Diff $diff = null, Matcher $match = null)
     {
         if (!isset($match)) {
-            $match = new Match();
+            $match = new Matcher();
         }
         if (!isset($diff)) {
             $diff = new Diff();
@@ -100,7 +100,7 @@ class Patch
     }
 
     /**
-     * @return Match
+     * @return Matcher
      */
     protected function getMatch()
     {

--- a/tests/DiffTest.php
+++ b/tests/DiffTest.php
@@ -919,4 +919,19 @@ class DiffTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testMultiByteEmojis()
+    {
+        // Replacing one emoji outside the BMP with another
+        $a = '😀';
+        $b = '😁';
+
+        // Would expect a to be removed and b to be added
+        $expectedChanges = array(
+            array(-1, '😀'),
+            array(1, '😁'),
+        );
+
+        $changes = $this->d->main($a, $b)->getChanges();
+        $this->assertEquals($expectedChanges, $changes);
+    }
 }

--- a/tests/MatchTest.php
+++ b/tests/MatchTest.php
@@ -29,14 +29,14 @@ namespace DiffMatchPatch;
 class MatchTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var Match
+     * @var Matcher
      */
     protected $m;
 
     protected  function setUp() {
         mb_internal_encoding('UTF-8');
 
-        $this->m = new Match();
+        $this->m = new Matcher();
     }
 
     public function testAlphabet()

--- a/tests/PatchTest.php
+++ b/tests/PatchTest.php
@@ -37,7 +37,7 @@ class PatchTest extends \PHPUnit_Framework_TestCase
      */
     protected $p;
     /**
-     * @var Match
+     * @var Matcher
      */
     protected $m;
 
@@ -45,7 +45,7 @@ class PatchTest extends \PHPUnit_Framework_TestCase
         mb_internal_encoding('UTF-8');
 
         $this->d = new Diff();
-        $this->m = new Match();
+        $this->m = new Matcher();
         // Assumes that Match->maxBits is 32.
         $this->m->setMaxBits(32);
         $this->p = new Patch($this->d, $this->m);


### PR DESCRIPTION
After switching from UCS-2LE to UCS-4LE, the internal encoding is not updated but left on UCS-2LE. This means that `mb_*` functions using the default internal encoding will not return the correct results. I've included a simple text case of replacing an emoji from outside the Unicode BMP with another. Before this fix, it was generating a diff with partial multibye characters, which could not be converted back to the internal encoding.